### PR TITLE
Change bots to always be in survival mode

### DIFF
--- a/src/main/java/carpet/commands/PlayerCommand.java
+++ b/src/main/java/carpet/commands/PlayerCommand.java
@@ -248,13 +248,7 @@ public class PlayerCommand
                 () -> DimensionArgumentType.getDimensionArgument(context, "dimension"),
                 () -> source.getWorld().dimension.getType()
         );
-        GameMode mode = GameMode.CREATIVE;
-        try
-        {
-            ServerPlayerEntity player = context.getSource().getPlayer();
-            mode = player.interactionManager.getGameMode();
-        }
-        catch (CommandSyntaxException ignored) {}
+        GameMode mode = GameMode.SURVIVAL;
         String playerName = StringArgumentType.getString(context, "player");
         if (playerName.length()>40)
         {


### PR DESCRIPTION
This is because we enabled spectator (with teleporting back to starting position) on the server, so we don't use spectator bots.